### PR TITLE
Добавление hostPath

### DIFF
--- a/charts/simple-app/CHANGELOG.md
+++ b/charts/simple-app/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.16.0
+
+* Add `.volumes[].hostPath` property to mount volume as a hostPath type
+
 # 0.15.2
 
 * Switch `.initJob` hook from `post-upgrade` to `pre-upgrade`

--- a/charts/simple-app/Chart.yaml
+++ b/charts/simple-app/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.15.2"
+version: "0.16.0"
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/simple-app/templates/deployment.yaml
+++ b/charts/simple-app/templates/deployment.yaml
@@ -44,7 +44,11 @@ spec:
         {{- end }}
         {{- range .Values.volumes }}
         - name: {{ .name }}
-          {{- if .emptyDir }}
+          {{- if .hostPath }}
+          hostPath:
+            path: {{ .hostPath }}
+            type: Directory
+          {{- else if .emptyDir }}
           emptyDir:
             sizeLimit: {{ .size }}
           {{- else if .size }}

--- a/charts/simple-app/templates/pvc.yaml
+++ b/charts/simple-app/templates/pvc.yaml
@@ -2,7 +2,7 @@
 {{- $labels := include "simple-app.labels" . | nindent 4 -}}
 
 {{ range .Values.volumes }}
-{{- if and (not .emptyDir) (and (not .secret) (not .configMap)) }}
+{{- if and (not .hostPath) and (not .emptyDir) (and (not .secret) (not .configMap)) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/simple-app/templates/pvc.yaml
+++ b/charts/simple-app/templates/pvc.yaml
@@ -2,7 +2,7 @@
 {{- $labels := include "simple-app.labels" . | nindent 4 -}}
 
 {{ range .Values.volumes }}
-{{- if and (not .hostPath) and (not .emptyDir) (and (not .secret) (not .configMap)) }}
+{{- if and (not .hostPath) (and (not .emptyDir) (and (not .secret) (not .configMap))) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/simple-app/tests/__snapshot__/initjob_test.yaml.snap
+++ b/charts/simple-app/tests/__snapshot__/initjob_test.yaml.snap
@@ -4,7 +4,7 @@ All manifests should match snapshot:
     kind: Job
     metadata:
       annotations:
-        helm.sh/hook: post-install,post-upgrade
+        helm.sh/hook: pre-install,pre-upgrade
         helm.sh/hook-delete-policy: before-hook-creation
         helm.sh/hook-weight: "-1"
       labels:

--- a/charts/simple-app/values.yaml
+++ b/charts/simple-app/values.yaml
@@ -69,6 +69,11 @@ initJob:
 shmSize: ""
 
 volumes: []
+  # if "hostPath" is set, it won't create anything, just mount hostPath on host to mountPath in container
+  # - name: data
+  #   mountPath: /data
+  #   hostPath: /home/ml/stuff
+
   # if "size" is set, it will create a PVC
   # - name: data
   #   size: 1Gi


### PR DESCRIPTION
Юзкейс: например, мне надо развернуть квадрант на конкретной тачке, на которой уже есть папка, где сохранены все коллекции. Раньше я использовал просто `docker run ... -v /host/path/:/container/path/`, но в simple-app кажется по дефолту так делать нельзя. Соответственно, я добавил `hostPath`, при указании которого не создается PersistentVolumeClaim, просто маунтится папка на машине к папке в контейнере. 
Естественно это будет работать только на конкретной тачке, поэтому нужно указывать `nodeSelector`. При желании можно добавить условие на то, что при указании `hostPath` обязательно должен быть указан `nodeSelector`. 

Проверено - для qdrant это работает. 